### PR TITLE
docs: add info

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,9 @@ const apiKey =
 const App = () => (
   <InstantSearch appId={appId} apiKey={apiKey} indexName={indexName}>
     <SearchBox defaultRefinement="iphone" />
+    <p>
+      Query Rules set up: <q>iphone</q>, <q>smartphone</q>
+    </p>
     <div className="twoCol">
       <div>
         <DynamicFacets>


### PR DESCRIPTION
This avoids you looking up what to search for, since just two query rules are set up in this demo